### PR TITLE
Add Troubleshooting Steps to Documentation: Addressing an installation error

### DIFF
--- a/docs/source/usage/installation.rst
+++ b/docs/source/usage/installation.rst
@@ -45,16 +45,15 @@ Troubleshoot
 
        pip uninstall parselmouth && pip install praat-parselmouth
 
-- error: subprocess-exited-with-error × python setup.py egg_info did not run successfully. | While trying to install the library, if you come up with this error, you should run:
-    .. code-block:: console
+- error: subprocess-exited-with-error × python setup.py egg_info did not run successfully.
+      
+    If you come up with this error while trying to install the library, you should run:
+    
+      .. code-block:: console
       
        pip install --upgrade pip
        pip install --upgrade setuptools
        pip install ez_setup
-
-and run again:
-    .. code-block:: console
-      
        pip install entrainment-metrics
 
 - Please, if you have any other error feel free to leave an issue in the github repository.

--- a/docs/source/usage/installation.rst
+++ b/docs/source/usage/installation.rst
@@ -45,4 +45,16 @@ Troubleshoot
 
        pip uninstall parselmouth && pip install praat-parselmouth
 
+- error: subprocess-exited-with-error × python setup.py egg_info did not run successfully. | While trying to install the library, if you come up with this error, you should run:
+    .. code-block:: console
+      
+       pip install --upgrade pip
+       pip install --upgrade setuptools
+       pip install ez_setup
+
+and run again:
+    .. code-block:: console
+      
+       pip install entrainment-metrics
+
 - Please, if you have any other error feel free to leave an issue in the github repository.


### PR DESCRIPTION
Added troubleshooting steps for 'subprocess-exited-with-error' during library installation. Recommends upgrading pip, setuptools, and installing ez_setup before retrying the installation command for entrainment-metrics.

When I was trying to install the library on Google Colab, I encountered this error:
![error](https://github.com/erikernst4/entrainment-metrics/assets/66437312/58e24c71-3b30-4af4-9018-f8dde294950a)

So, I googled it a little and encountered the solution of upgrading those things, and it worked.
It may be useful for others to have the troubleshooting for that :)